### PR TITLE
Handle both null and undefined for attributes that should be sorted

### DIFF
--- a/backbone-collection-sorting.js
+++ b/backbone-collection-sorting.js
@@ -35,7 +35,7 @@
           sortType = this.sorting.type || 'numeric';
       
       // If attributes don't exist, set back
-      if (a === void 0 || b === void 0) return -1;
+      if(!a || !b) return -1;
 
       // Alphabetical
       if ( sortType == 'alpha' ) {


### PR DESCRIPTION
In using this plugin, a model attribute was sorting on was null which caused the library to throw  this error: 

TypeError: Cannot read property 'toString' of null

So, instead of explicitly checking for undefined (void 0) , it's probably best to check for anything that falsey which would include null, undefined and empty string.
